### PR TITLE
Update coffeescript to latest 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,10 +1351,10 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    "coffeescript": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz",
+      "integrity": "sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "http://github.com/spadgos/getafix.git"
   },
   "dependencies": {
-    "coffee-script": "^1.12.7",
+    "coffeescript": "^2.5.1",
     "debug": "^4.3.1",
     "glob": "^7.1.6",
     "got": "^11.8.1",

--- a/src/getafix.js
+++ b/src/getafix.js
@@ -1,5 +1,5 @@
 const _ = require('underscore');
-const Coffee = require('coffee-script');
+const Coffee = require('coffeescript');
 const debug = require('debug')('getafix');
 const fs = require('fs').promises;
 const Glob = require('glob');


### PR DESCRIPTION
`coffee-script` is deprecated, `coffeescript` is the latest.

The breaking changes in the major version don't affect the minor use
case this has.